### PR TITLE
Fixed exception on post syncdb

### DIFF
--- a/djangocms_page_meta/models.py
+++ b/djangocms_page_meta/models.py
@@ -71,7 +71,7 @@ class PageMeta(PageExtension):
                                   help_text=_(u'Use Article for generic pages.'))
 
     class Meta:
-        verbose_name = _(u'Page meta information (all languages)')
+        verbose_name = _(u'Page meta info (all languages)')
 extension_pool.register(PageMeta)
 
 
@@ -89,7 +89,7 @@ class TitleMeta(TitleExtension):
             return None
 
     class Meta:
-        verbose_name = _(u'Page meta information (language-dependent)')
+        verbose_name = _(u'Page meta info (language-dependent)')
 extension_pool.register(TitleMeta)
 
 


### PR DESCRIPTION
Using a database backend other than sqlite you get the followeing error on post-syncdb processing: 
`django.db.utils.DataError: value too long for type character varying(50)`

This happens because Django use the verbose name of the models  (which is too long)  to create the permission description text in `auth_permission`.
