### PR TITLE
fix issue when no page instance

### DIFF
--- a/djangocms_page_meta/templatetags/page_meta_tags.py
+++ b/djangocms_page_meta/templatetags/page_meta_tags.py
@@ -20,8 +20,11 @@ class MetaFromPage(Tag):
     )
 
     def render_tag(self, context, page, varname):
-        language = get_language_from_request(context['request'])
-        meta = get_page_meta(page, language)
-        context[varname] = meta
+        try:
+            language = get_language_from_request(context['request'])
+            meta = get_page_meta(page, language)
+            context[varname] = meta
+        except: 
+            pass
         return ''
 register.tag(MetaFromPage)


### PR DESCRIPTION
getting the following error on 404 pages and within some tests:

django.utils.functional in inner
AttributeError: 'NoneType' object has no attribute 'site_id'

Stacktrace (most recent call last):

  File "django/core/handlers/base.py", line 150, in get_response
    response = callback(request, **param_dict)
  File "django/utils/decorators.py", line 105, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "django/views/defaults.py", line 31, in page_not_found
    body = template.render(RequestContext(request, {'request_path': request.path}))
  File "django/template/base.py", line 148, in render
    return self._render(context)
  File "django/template/base.py", line 142, in _render
    return self.nodelist.render(context)
  File "django/template/base.py", line 844, in render
    bit = self.render_node(node, context)
  File "django/template/base.py", line 858, in render_node
    return node.render(context)
  File "django/template/loader_tags.py", line 126, in render
    return compiled_parent._render(context)
  File "django/template/base.py", line 142, in _render
    return self.nodelist.render(context)
  File "django/template/base.py", line 844, in render
    bit = self.render_node(node, context)
  File "django/template/base.py", line 858, in render_node
    return node.render(context)
  File "django/template/defaulttags.py", line 312, in render
    return nodelist.render(context)
  File "django/template/base.py", line 844, in render
    bit = self.render_node(node, context)
  File "django/template/base.py", line 858, in render_node
    return node.render(context)
  File "classytags/core.py", line 106, in render
    return self.render_tag(context, **kwargs)
  File "djangocms_page_meta/templatetags/page_meta_tags.py", line 24, in render_tag
    meta = get_page_meta(page, language)
  File "djangocms_page_meta/utils.py", line 27, in get_page_meta
    meta_key = get_cache_key(page, language)
  File "djangocms_page_meta/utils.py", line 9, in get_cache_key
    site_id = page.site_id
  File "django/utils/functional.py", line 225, in inner
    return func(self._wrapped, *args)

I have fixed it with this commit 