### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/djangocms_page_meta/admin.py
+++ b/djangocms_page_meta/admin.py
@@ -33,7 +33,7 @@ class PageMetaAdmin(PageExtensionAdmin):
 
     class Media:
         css = {
-            'all': ('%sdjangocms_page_meta/css/%s' % (
+            'all': ('{0!s}djangocms_page_meta/css/{1!s}'.format(
                 settings.STATIC_URL, 'djangocms_page_meta_admin.css'),)
         }
 
@@ -51,7 +51,7 @@ class TitleMetaAdmin(TitleExtensionAdmin):
 
     class Media:
         css = {
-            'all': ('%sdjangocms_page_meta/css/%s' % (
+            'all': ('{0!s}djangocms_page_meta/css/{1!s}'.format(
                 settings.STATIC_URL, 'djangocms_page_meta_admin.css'),)
         }
 

--- a/djangocms_page_meta/cms_toolbar.py
+++ b/djangocms_page_meta/cms_toolbar.py
@@ -57,7 +57,7 @@ class PageToolbarMeta(CMSToolbar):
                     url = reverse('admin:djangocms_page_meta_pagemeta_change',
                                   args=(page_extension.pk,))
                 else:
-                    url = '%s?extended_object=%s' % (
+                    url = '{0!s}?extended_object={1!s}'.format(
                         reverse('admin:djangocms_page_meta_pagemeta_add'),
                         self.page.pk)
             except NoReverseMatch:
@@ -78,7 +78,7 @@ class PageToolbarMeta(CMSToolbar):
                         url = reverse('admin:djangocms_page_meta_titlemeta_change',
                                       args=(title_extension.pk,))
                     else:
-                        url = '%s?extended_object=%s' % (
+                        url = '{0!s}?extended_object={1!s}'.format(
                             reverse('admin:djangocms_page_meta_titlemeta_add'),
                             title.pk)
                 except NoReverseMatch:

--- a/djangocms_page_meta/models.py
+++ b/djangocms_page_meta/models.py
@@ -90,7 +90,7 @@ class PageMeta(PageExtension):
         verbose_name = _('Page meta info (all languages)')
 
     def __str__(self):
-        return 'Page meta for %s' % self.extended_object
+        return 'Page meta for {0!s}'.format(self.extended_object)
 extension_pool.register(PageMeta)
 
 
@@ -120,7 +120,7 @@ class TitleMeta(TitleExtension):
         verbose_name = _('Page meta info (language-dependent)')
 
     def __str__(self):
-        return 'Title Meta for %s' % self.extended_object
+        return 'Title Meta for {0!s}'.format(self.extended_object)
 
     @property
     def locale(self):

--- a/djangocms_page_meta/south_migrations/0001_initial.py
+++ b/djangocms_page_meta/south_migrations/0001_initial.py
@@ -4,8 +4,8 @@ from south.v2 import SchemaMigration
 
 from django.contrib.auth import get_user_model
 User = get_user_model()
-user_orm_label = '%s.%s' % (User._meta.app_label, User._meta.object_name)
-user_model_label = '%s.%s' % (User._meta.app_label, User._meta.module_name)
+user_orm_label = '{0!s}.{1!s}'.format(User._meta.app_label, User._meta.object_name)
+user_model_label = '{0!s}.{1!s}'.format(User._meta.app_label, User._meta.module_name)
 
 
 class Migration(SchemaMigration):
@@ -149,7 +149,7 @@ class Migration(SchemaMigration):
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'image': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['filer.File']", 'null': 'True', 'blank': 'True'}),
             'og_app_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
-            'og_author': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['%s']" % user_orm_label, 'null': 'True', 'blank': 'True'}),
+            'og_author': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['{0!s}']".format(user_orm_label), 'null': 'True', 'blank': 'True'}),
             'og_author_fbid': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '16', 'blank': 'True'}),
             'og_author_url': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
             'og_publisher': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
@@ -180,7 +180,7 @@ class Migration(SchemaMigration):
             'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
             'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
-            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'owned_files'", 'null': 'True', 'to': u"orm['%s']" % user_orm_label}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'owned_files'", 'null': 'True', 'to': u"orm['{0!s}']".format(user_orm_label)}),
             'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'polymorphic_filer.file_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
             'sha1': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '40', 'blank': 'True'}),
             'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
@@ -193,7 +193,7 @@ class Migration(SchemaMigration):
             'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
             'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'filer_owned_folders'", 'null': 'True', 'to': u"orm['%s']" % user_orm_label}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'filer_owned_folders'", 'null': 'True', 'to': u"orm['{0!s}']".format(user_orm_label)}),
             'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['filer.Folder']"}),
             'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
             'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),

--- a/djangocms_page_meta/south_migrations/0002_auto__add_field_titlemeta_og_description__add_field_titlemeta_twitter_.py
+++ b/djangocms_page_meta/south_migrations/0002_auto__add_field_titlemeta_og_description__add_field_titlemeta_twitter_.py
@@ -4,8 +4,8 @@ from south.v2 import SchemaMigration
 
 from django.contrib.auth import get_user_model
 User = get_user_model()
-user_orm_label = '%s.%s' % (User._meta.app_label, User._meta.object_name)
-user_model_label = '%s.%s' % (User._meta.app_label, User._meta.module_name)
+user_orm_label = '{0!s}.{1!s}'.format(User._meta.app_label, User._meta.object_name)
+user_model_label = '{0!s}.{1!s}'.format(User._meta.app_label, User._meta.module_name)
 
 
 class Migration(SchemaMigration):
@@ -140,7 +140,7 @@ class Migration(SchemaMigration):
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'image': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'djangocms_page_meta_page'", 'null': 'True', 'to': "orm['filer.File']"}),
             'og_app_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
-            'og_author': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['%s']" % user_orm_label, 'null': 'True', 'blank': 'True'}),
+            'og_author': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['{0!s}']".format(user_orm_label), 'null': 'True', 'blank': 'True'}),
             'og_author_fbid': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '16', 'blank': 'True'}),
             'og_author_url': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
             'og_publisher': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
@@ -174,7 +174,7 @@ class Migration(SchemaMigration):
             'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'}),
             'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
-            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'owned_files'", 'null': 'True', 'to': u"orm['%s']" % user_orm_label}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'owned_files'", 'null': 'True', 'to': u"orm['{0!s}']".format(user_orm_label)}),
             'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'polymorphic_filer.file_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
             'sha1': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '40', 'blank': 'True'}),
             'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
@@ -187,7 +187,7 @@ class Migration(SchemaMigration):
             'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
             'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'filer_owned_folders'", 'null': 'True', 'to': u"orm['%s']" % user_orm_label}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'filer_owned_folders'", 'null': 'True', 'to': u"orm['{0!s}']".format(user_orm_label)}),
             'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['filer.Folder']"}),
             'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
             'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ version = djangocms_page_meta.__version__
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     print('You probably want to also tag the version now:')
-    print('  git tag -a %s -m "version %s"' % (version, version))
+    print('  git tag -a {0!s} -m "version {1!s}"'.format(version, version))
     print('  git push --tags')
     sys.exit()
 

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -25,8 +25,8 @@ class TemplateMetaTest(BaseTest):
 
         response = self.client.get('/en/')
         self.assertContains(response, '<meta name="twitter:domain" content="example.com">')
-        self.assertContains(response, '<meta itemprop="datePublished" content="%s">' % page1.publication_date.isoformat())
-        self.assertContains(response, '<meta property="article:expiration_time" content="%s">' % page1.publication_end_date.isoformat())
+        self.assertContains(response, '<meta itemprop="datePublished" content="{0!s}">'.format(page1.publication_date.isoformat()))
+        self.assertContains(response, '<meta property="article:expiration_time" content="{0!s}">'.format(page1.publication_end_date.isoformat()))
         self.assertContains(response, '<meta property="article:publisher" content="https://facebook.com/FakeUser">')
 
     def test_title_meta(self):

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -52,7 +52,7 @@ class ToolbarTest(BaseTest):
         toolbar.get_left_items()
         page_menu = toolbar.menus['page']
         meta_menu = page_menu.find_items(SubMenu, name=force_unicode(PAGE_META_MENU_TITLE))[0].item
-        self.assertEqual(len(meta_menu.find_items(ModalItem, name="%s ..." % force_unicode(PAGE_META_ITEM_TITLE))), 1)
+        self.assertEqual(len(meta_menu.find_items(ModalItem, name="{0!s} ...".format(force_unicode(PAGE_META_ITEM_TITLE)))), 1)
 
     @override_settings(CMS_PERMISSION=True)
     def test_perm_permissions(self):
@@ -80,7 +80,7 @@ class ToolbarTest(BaseTest):
         toolbar.get_left_items()
         page_menu = toolbar.menus['page']
         meta_menu = page_menu.find_items(SubMenu, name=force_unicode(PAGE_META_MENU_TITLE))[0].item
-        self.assertEqual(len(meta_menu.find_items(ModalItem, name="%s ..." % force_unicode(PAGE_META_ITEM_TITLE))), 1)
+        self.assertEqual(len(meta_menu.find_items(ModalItem, name="{0!s} ...".format(force_unicode(PAGE_META_ITEM_TITLE)))), 1)
         self.assertEqual(len(meta_menu.find_items(ModalItem)), len(self.languages) + 1)
 
     def test_toolbar_with_items(self):
@@ -95,12 +95,12 @@ class ToolbarTest(BaseTest):
         toolbar.get_left_items()
         page_menu = toolbar.menus['page']
         meta_menu = page_menu.find_items(SubMenu, name=force_unicode(PAGE_META_MENU_TITLE))[0].item
-        pagemeta_menu = meta_menu.find_items(ModalItem, name="%s ..." % force_unicode(PAGE_META_ITEM_TITLE))
+        pagemeta_menu = meta_menu.find_items(ModalItem, name="{0!s} ...".format(force_unicode(PAGE_META_ITEM_TITLE)))
         self.assertEqual(len(pagemeta_menu), 1)
         self.assertTrue(pagemeta_menu[0].item.url.startswith(reverse('admin:djangocms_page_meta_pagemeta_change', args=(page_ext.pk,))))
         for title in page1.title_set.all():
             language = get_language_object(title.language)
-            titlemeta_menu = meta_menu.find_items(ModalItem, name="%s ..." % language['name'])
+            titlemeta_menu = meta_menu.find_items(ModalItem, name="{0!s} ...".format(language['name']))
             self.assertEqual(len(titlemeta_menu), 1)
             try:
                 title_ext = TitleMeta.objects.get(extended_object_id=title.pk)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:nephila:djangocms-page-meta?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:nephila:djangocms-page-meta?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)