### PR TITLE
Require dajngo-meta>=1.0 and stop depending on django-meta-mixin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,8 @@ setup(
     include_package_data=True,
     install_requires=(
         'django-cms>=3.0',
-        'django-meta>=0.1.0',
+        'django-meta>=1.0',
         'django-filer>=0.9.5',
-        'django-meta-mixin',
     ),
     license='BSD',
     zip_safe=False,


### PR DESCRIPTION
As of ver 1.0 of django-meta django-meta-mixin is not needed anymore.

Fixes #44