### PR TITLE
Remove description field from page admin

### DIFF
--- a/djangocms_page_meta/admin.py
+++ b/djangocms_page_meta/admin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+from cms.admin import pageadmin
 from cms.extensions import PageExtensionAdmin, TitleExtensionAdmin
 from django.conf import settings
 from django.contrib import admin
@@ -8,6 +9,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from .forms import TitleMetaAdminForm
 from .models import GenericMetaAttribute, PageMeta, TitleMeta
+
+admin.site.unregister(pageadmin.Page)
 
 
 class GenericAttributePageInline(admin.TabularInline):
@@ -74,3 +77,18 @@ class TitleMetaAdmin(TitleExtensionAdmin):
         return {}
 
 admin.site.register(TitleMeta, TitleMetaAdmin)
+
+
+class PageAdmin(pageadmin.PageAdmin):
+    """
+    Remove the meta description field from the page admin (we have this in django-cms-meta)
+    """
+    def get_form(self, request, obj=None, **kwargs):
+        form = super(PageAdmin, self).get_form(request, obj, **kwargs)
+        try:
+            del form.base_fields['meta_description']
+        except KeyError:
+            pass
+
+        return form
+admin.site.register(pageadmin.Page, PageAdmin)


### PR DESCRIPTION
Thanks @macolo for suggesting this approach
Code taken from https://github.com/what-digital/djangocms-page-remove-meta-descr

Fix #50 
