### PR TITLE
Filer canonical url

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,7 +89,7 @@ tests, including testing other Python versions with tox::
 
 To get flake8 and tox install them into your virtualenv:
 
-    pip install -r requirements-test.txt
+    $ pip install -r requirements-test.txt
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,7 +3,7 @@ Contributing
 ============
 
 Contributions are welcome, and they are greatly appreciated! Every
-little bit helps, and credit will always be given. 
+little bit helps, and credit will always be given.
 
 You can contribute in many ways:
 
@@ -84,10 +84,12 @@ Now you can make your changes locally.
 tests, including testing other Python versions with tox::
 
     $ flake8 djangocms_page_meta tests
-	$ python setup.py test
+    $ python setup.py test
     $ tox
 
-To get flake8 and tox, just pip install them into your virtualenv. 
+To get flake8 and tox install them into your virtualenv:
+
+    pip install -r requirements-test.txt
 
 6. Commit your changes and push your branch to GitHub::
 
@@ -106,7 +108,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, and 3.3, and for PyPy. Check 
+3. The pull request should work for Python 2.6, 2.7, and 3.3, and for PyPy. Check
    https://travis-ci.org/nephila/djangocms-page-meta/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/djangocms_page_meta/utils.py
+++ b/djangocms_page_meta/utils.py
@@ -64,7 +64,7 @@ def get_page_meta(page, language):
             if not meta.gplus_description:
                 meta.gplus_description = meta.description
             if titlemeta.image:
-                meta.image = title.titlemeta.image.url
+                meta.image = title.titlemeta.image.canonical_url or title.titlemeta.image.url
             for item in titlemeta.extra.all():
                 attribute = item.attribute
                 if not attribute:
@@ -125,7 +125,7 @@ def get_page_meta(page, language):
                     # djangocms-page-tags not available
                     pass
             if not meta.image and pagemeta.image:
-                meta.image = pagemeta.image.url
+                meta.image = pagemeta.image.canonical_url or pagemeta.image.url
             for item in pagemeta.extra.all():
                 attribute = item.attribute
                 if not attribute:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,4 @@ django-nose>=1.2
 flake8
 https://github.com/nephila/djangocms-helper/archive/develop.zip
 djangocms-page-tags
+tox


### PR DESCRIPTION
The idea is share the image using the `filer_file.canonical_url` if django-filer is [configured](http://django-filer.readthedocs.io/en/latest/installation.html#canonical-urls) otherwise use the `filer_file.url` property.
