### PR TITLE
Django 1.11 / Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: python
 sudo: false
 
 python:
+  - 3.6
   - 3.5
   - 3.4
   - 2.7
@@ -14,13 +15,14 @@ env:
   - TOXENV='pep8'
   - TOXENV='docs'
   - TOXENV='isort'
-  - DJANGO='django18' CMS='cms32'
-  - DJANGO='django18' CMS='cms33'
   - DJANGO='django18' CMS='cms34'
-  - DJANGO='django19' CMS='cms32'
-  - DJANGO='django19' CMS='cms33'
   - DJANGO='django19' CMS='cms34'
   - DJANGO='django110' CMS='cms34'
+  - DJANGO='django111' CMS='cms34'
+  - DJANGO='django18' CMS='cms35'
+  - DJANGO='django19' CMS='cms35'
+  - DJANGO='django110' CMS='cms35'
+  - DJANGO='django111' CMS='cms35'
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
@@ -28,6 +30,7 @@ install:
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export PYVER=py27; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then export PYVER=py34; fi"
   - "if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PYVER=py35; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PYVER=py36; fi"
   - "if [[ ${DJANGO}z != 'z' ]]; then export TOXENV=$PYVER-$DJANGO-$CMS; fi"
 
 # command to run tests, e.g. python setup.py test
@@ -52,4 +55,34 @@ matrix:
   - python: 3.4
     env: TOXENV='isort'
   - python: 3.4
+    env: TOXENV='docs'
+  - python: 3.4
+    env: DJANGO='django18' CMS='cms34'
+  - python: 3.4
+    env: DJANGO='django19' CMS='cms34'
+  - python: 3.4
+    env: DJANGO='django110' CMS='cms34'
+  - python: 3.4
+    env: DJANGO='django18' CMS='cms35'
+  - python: 3.4
+    env: DJANGO='django19' CMS='cms35'
+  - python: 3.4
+    env: DJANGO='django110' CMS='cms35'
+  - python: 3.5
+    env: DJANGO='django18' CMS='cms34'
+  - python: 3.5
+    env: DJANGO='django19' CMS='cms34'
+  - python: 3.5
+    env: DJANGO='django110' CMS='cms34'
+  - python: 3.5
+    env: DJANGO='django18' CMS='cms35'
+  - python: 3.5
+    env: DJANGO='django19' CMS='cms35'
+  - python: 3.5
+    env: DJANGO='django110' CMS='cms35'
+  - python: 3.5
+    env: TOXENV='pep8'
+  - python: 3.5
+    env: TOXENV='isort'
+  - python: 3.5
     env: TOXENV='docs'

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,9 +4,11 @@
 History
 *******
 
-0.7.1 (unreleased)
+0.8.0 (unreleased)
 ==================
 
+* Add Django 1.11 support
+* Drop django CMS 3.2, 3.3
 * Add support for filer canonical URL
 * Do not fail if request is not in context
 

--- a/README.rst
+++ b/README.rst
@@ -32,11 +32,11 @@ djangocms-page-meta
 
 Meta tag information for django CMS 3 pages
 
-Python: 2.7, 3.4, 3.5
+Python: 2.7, 3.4, 3.5. 3.6
 
-Django: 1.8 to 1.10
+Django: 1.8 to 1.11
 
-django CMS: 3.2 to 3.4
+django CMS: 3.4 (and develop/3.5)
 
 .. warning:: Since version 0.7, the support for Python 2.6, Python 3.3, Django<1.8 and django CMS<3.2
              has been dropped

--- a/djangocms_page_meta/__init__.py
+++ b/djangocms_page_meta/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-__version__ = '0.7.0.dev1'
+__version__ = '0.8.0.dev1'
 __author__ = 'Iacopo Spalletti <i.spalletti@nephila.it>'
 
 default_app_config = 'djangocms_page_meta.apps.PageMetaConfig'

--- a/djangocms_page_meta/cms_toolbars.py
+++ b/djangocms_page_meta/cms_toolbars.py
@@ -8,17 +8,11 @@ from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
 from cms.utils import get_cms_setting
 from cms.utils.i18n import get_language_list, get_language_object
+from cms.utils.permissions import has_page_permission
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from .models import PageMeta, TitleMeta
-
-try:
-    from cms.utils.permissions import has_page_permission
-    has_page_change_permission = None
-except ImportError:
-    from cms.utils.permissions import has_page_change_permission
-
 
 PAGE_META_MENU_TITLE = _('Meta-information')
 PAGE_META_ITEM_TITLE = _('Common')
@@ -36,23 +30,16 @@ class PageToolbarMeta(CMSToolbar):
 
         # check global permissions if CMS_PERMISSIONS is active
         if get_cms_setting('PERMISSION'):
-            if not has_page_change_permission:
-                has_global_current_page_change_permission = has_page_permission(
-                    self.request.user, self.request.current_page, 'change'
-                )
-            else:
-                has_global_current_page_change_permission = has_page_change_permission(
-                    self.request
-                )
+            has_global_current_page_change_permission = has_page_permission(
+                self.request.user, self.request.current_page, 'change'
+            )
         else:
             has_global_current_page_change_permission = False
             # check if user has page edit permission
-        if not has_page_change_permission:
-            can_change = (self.request.current_page and
-                          self.request.current_page.has_change_permission(self.request.user))
-        else:
-            can_change = (self.request.current_page and
-                          self.request.current_page.has_change_permission(self.request))
+        can_change = (
+            self.request.current_page and
+            self.request.current_page.has_change_permission(self.request.user)
+        )
         if has_global_current_page_change_permission or can_change:
             not_edit_mode = not self.toolbar.edit_mode
             current_page_menu = self.toolbar.get_or_create_menu('page')

--- a/djangocms_page_meta/cms_toolbars.py
+++ b/djangocms_page_meta/cms_toolbars.py
@@ -6,13 +6,18 @@ from cms.cms_toolbars import PAGE_MENU_SECOND_BREAK
 from cms.toolbar.items import Break
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
-from cms.utils import get_cms_setting
 from cms.utils.i18n import get_language_list, get_language_object
 from cms.utils.permissions import has_page_permission
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from .models import PageMeta, TitleMeta
+
+try:
+    from cms.utils import get_cms_setting
+except ImportError:  # pragma: no cover
+    from cms.utils.conf import get_cms_setting
+
 
 PAGE_META_MENU_TITLE = _('Meta-information')
 PAGE_META_ITEM_TITLE = _('Common')

--- a/djangocms_page_meta/models.py
+++ b/djangocms_page_meta/models.py
@@ -19,7 +19,7 @@ from .utils import get_cache_key
 
 try:
     from aldryn_snake.template_api import registry
-except:
+except ImportError:
     registry = None
 
 

--- a/djangocms_page_meta/templatetags/page_meta_tags.py
+++ b/djangocms_page_meta/templatetags/page_meta_tags.py
@@ -12,6 +12,7 @@ from ..utils import get_page_meta
 register = template.Library()
 
 
+@register.tag(name='page_meta')
 class MetaFromPage(Tag):
     name = 'page_meta'
     options = Options(
@@ -29,4 +30,3 @@ class MetaFromPage(Tag):
             meta = Meta()
         context[varname] = meta
         return ''
-register.tag(MetaFromPage)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,6 @@ mock>=1.0.1
 nose>=1.3.0
 django-nose>=1.2
 flake8
+https://github.com/nephila/djangocms-page-tags/archive/develop.zip
 https://github.com/nephila/djangocms-helper/archive/develop.zip
-djangocms-page-tags
 tox

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=(
-        'django-cms>=3.2',
+        'django-cms>=3.4',
         'django-meta>=1.3',
         'django-filer>=1.2',
     ),
@@ -54,10 +54,12 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -28,7 +28,7 @@ class TemplateMetaTest(BaseTest):
         page1.publish('it')
         page1.publish('en')
 
-        response = self.client.get('/en/')
+        response = self.client.get(page1.get_public_url('en'))
         self.assertContains(response, '<meta name="twitter:domain" content="example.com">')
         self.assertContains(response, '<meta itemprop="datePublished" content="%s">' % page1.publication_date.isoformat())
         self.assertContains(response, '<meta property="article:expiration_time" content="%s">' % page1.publication_end_date.isoformat())
@@ -60,22 +60,22 @@ class TemplateMetaTest(BaseTest):
         page1.publish('en')
 
         # Italian language
-        response = self.client.get('/it/')
+        response = self.client.get(page1.get_public_url('it'))
         response.render()
         self.assertContains(response, '<meta name="twitter:description" content="twitter - lorem ipsum - italian">')
         self.assertContains(response, '<meta itemprop="description" content="gplus - lorem ipsum - italian">')
         self.assertContains(response, '<meta property="og:description" content="opengraph - lorem ipsum - italian">')
         self.assertContains(response, '<meta property="og:title" content="pagina uno">')
-        self.assertContains(response, '<meta property="og:url" content="http://example.com/it/">')
+        self.assertContains(response, '<meta property="og:url" content="http://example.com%s">' % page1.get_public_url('it'))
         self.assertContains(response, '<meta custom="attr" content="foo-it">')
 
         # English language
-        response = self.client.get('/en/')
+        response = self.client.get(page1.get_public_url('en'))
         self.assertContains(response, '<meta name="twitter:description" content="twitter - lorem ipsum - english">')
         self.assertContains(response, '<meta itemprop="description" content="gplus - lorem ipsum - english">')
         self.assertContains(response, '<meta property="og:description" content="opengraph - lorem ipsum - english">')
         self.assertContains(response, '<meta property="og:title" content="page one">')
-        self.assertContains(response, '<meta property="og:url" content="http://example.com/en/">')
+        self.assertContains(response, '<meta property="og:url" content="http://example.com%s">' % page1.get_public_url('en'))
         self.assertContains(response, '<meta custom="attr" content="foo-en">')
 
     def test_fallbacks(self):
@@ -101,28 +101,28 @@ class TemplateMetaTest(BaseTest):
         title_ext_en = title_en.titlemeta
 
         # Italian language
-        response = self.client.get('/it/')
+        response = self.client.get(page1.get_public_url('it'))
         response.render()
         self.assertContains(response, '<meta name="description" content="base lorem ipsum - italian">')
         self.assertContains(response, '<meta name="twitter:description" content="base lorem ipsum - italian">')
         self.assertContains(response, '<meta itemprop="description" content="base lorem ipsum - italian">')
         self.assertContains(response, '<meta property="og:description" content="base lorem ipsum - italian">')
         self.assertContains(response, '<meta property="og:title" content="pagina uno">')
-        self.assertContains(response, '<meta property="og:url" content="http://example.com/it/">')
+        self.assertContains(response, '<meta property="og:url" content="http://example.com%s">' % page1.get_public_url('it'))
 
         # English language
-        response = self.client.get('/en/')
+        response = self.client.get(page1.get_public_url('en'))
         self.assertContains(response, '<meta name="description" content="base lorem ipsum - english">')
         self.assertContains(response, '<meta name="twitter:description" content="base lorem ipsum - english">')
         self.assertContains(response, '<meta itemprop="description" content="base lorem ipsum - english">')
         self.assertContains(response, '<meta property="og:description" content="base lorem ipsum - english">')
         self.assertContains(response, '<meta property="og:title" content="page one">')
-        self.assertContains(response, '<meta property="og:url" content="http://example.com/en/">')
+        self.assertContains(response, '<meta property="og:url" content="http://example.com%s">' % page1.get_public_url('en'))
 
         title_ext_en.description = 'custom description'
         title_ext_en.save()
         page1.publish('en')
-        response = self.client.get('/en/')
+        response = self.client.get(page1.get_public_url('en'))
         self.assertContains(response, '<meta name="description" content="custom description">')
         self.assertContains(response, '<meta name="twitter:description" content="custom description">')
         self.assertContains(response, '<meta itemprop="description" content="custom description">')
@@ -134,7 +134,7 @@ class TemplateMetaTest(BaseTest):
         title_ext_en.og_description = 'og custom description'
         title_ext_en.save()
         page1.publish('en')
-        response = self.client.get('/en/')
+        response = self.client.get(page1.get_public_url('en'))
         self.assertContains(response, '<meta name="description" content="custom description">')
         self.assertContains(response, '<meta name="twitter:description" content="twitter custom description">')
         self.assertContains(response, '<meta property="og:description" content="og custom description">')
@@ -145,10 +145,10 @@ class TemplateMetaTest(BaseTest):
         page2.publish('en')
         # English language
         # A page with no title meta, and yet the meta description is there
-        response = self.client.get('/en/page-two/')
+        response = self.client.get(page2.get_public_url('en'))
         self.assertContains(response, '<meta name="description" content="base lorem ipsum - english">')
         self.assertContains(response, '<meta name="twitter:description" content="base lorem ipsum - english">')
         self.assertContains(response, '<meta itemprop="description" content="base lorem ipsum - english">')
         self.assertContains(response, '<meta property="og:description" content="base lorem ipsum - english">')
         self.assertNotContains(response, '<meta property="og:title" content="page one">')
-        self.assertNotContains(response, '<meta property="og:url" content="http://example.com/en/">')
+        self.assertNotContains(response, '<meta property="og:url" content="http://example.com%s">' % page1.get_public_url('en'))

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -52,10 +52,7 @@ class ToolbarTest(BaseTest):
         toolbar.get_left_items()
         page_menu = toolbar.menus['page']
         meta_menu = page_menu.find_items(SubMenu, name=force_text(PAGE_META_MENU_TITLE))[0].item
-        try:
-            self.assertEqual(len(meta_menu.find_items(ModalItem, name="{0}...".format(force_text(PAGE_META_ITEM_TITLE)))), 1)
-        except AssertionError:
-            self.assertEqual(len(meta_menu.find_items(ModalItem, name="{0} ...".format(force_text(PAGE_META_ITEM_TITLE)))), 1)
+        self.assertEqual(len(meta_menu.find_items(ModalItem, name="{0}...".format(force_text(PAGE_META_ITEM_TITLE)))), 1)
 
     @override_settings(CMS_PERMISSION=True)
     def test_perm_permissions(self):
@@ -102,10 +99,7 @@ class ToolbarTest(BaseTest):
             toolbar.get_left_items()
             page_menu = toolbar.menus['page']
             meta_menu = page_menu.find_items(SubMenu, name=force_text(PAGE_META_MENU_TITLE))[0].item
-            try:
-                self.assertEqual(len(meta_menu.find_items(ModalItem, name="{0}...".format(force_text(PAGE_META_ITEM_TITLE)))), 1)
-            except AssertionError:
-                self.assertEqual(len(meta_menu.find_items(ModalItem, name="{0} ...".format(force_text(PAGE_META_ITEM_TITLE)))), 1)
+            self.assertEqual(len(meta_menu.find_items(ModalItem, name="{0}...".format(force_text(PAGE_META_ITEM_TITLE)))), 1)
             self.assertEqual(len(meta_menu.find_items(ModalItem)), len(NEW_CMS_LANGS[1])+1)
 
     def test_toolbar_with_items(self):
@@ -120,21 +114,13 @@ class ToolbarTest(BaseTest):
         toolbar.get_left_items()
         page_menu = toolbar.menus['page']
         meta_menu = page_menu.find_items(SubMenu, name=force_text(PAGE_META_MENU_TITLE))[0].item
-        try:
-            pagemeta_menu = meta_menu.find_items(ModalItem, name="{0}...".format(force_text(PAGE_META_ITEM_TITLE)))
-            self.assertEqual(len(pagemeta_menu), 1)
-        except AssertionError:
-            pagemeta_menu = meta_menu.find_items(ModalItem, name="{0} ...".format(force_text(PAGE_META_ITEM_TITLE)))
-            self.assertEqual(len(pagemeta_menu), 1)
+        pagemeta_menu = meta_menu.find_items(ModalItem, name="{0}...".format(force_text(PAGE_META_ITEM_TITLE)))
+        self.assertEqual(len(pagemeta_menu), 1)
         self.assertTrue(pagemeta_menu[0].item.url.startswith(reverse('admin:djangocms_page_meta_pagemeta_change', args=(page_ext.pk,))))
         for title in page1.title_set.all():
             language = get_language_object(title.language)
-            try:
-                titlemeta_menu = meta_menu.find_items(ModalItem, name='{0}...'.format(language['name']))
-                self.assertEqual(len(titlemeta_menu), 1)
-            except AssertionError:
-                titlemeta_menu = meta_menu.find_items(ModalItem, name='{0} ...'.format(language['name']))
-                self.assertEqual(len(titlemeta_menu), 1)
+            titlemeta_menu = meta_menu.find_items(ModalItem, name='{0}...'.format(language['name']))
+            self.assertEqual(len(titlemeta_menu), 1)
             try:
                 title_ext = TitleMeta.objects.get(extended_object_id=title.pk)
                 self.assertTrue(titlemeta_menu[0].item.url.startswith(reverse('admin:djangocms_page_meta_titlemeta_change', args=(title_ext.pk,))))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,isort,py{35,34,27}-django{110}-cms{34},py{35,34,27}-django{19}-cms{34,33,32},py{35,34,27}-django{18}-cms{34,33,32}
+envlist = docs,pep8,isort,py{36,35,34,27}-django{110,111}-cms{34},py{35,34,27}-django{19}-cms{34},py{35,34,27}-django{18}-cms{34}
 
 [testenv]
 commands = {env:COMMAND:python} setup.py test
@@ -16,9 +16,12 @@ deps =
     django110: django-mptt>=0.8
     django110: django-taggit>=0.18
     django110: django-polymorphic>=0.9
-    django110: https://github.com/divio/django-filer/archive/develop.zip
-    cms32: https://github.com/divio/django-cms/archive/release/3.2.x.zip
-    cms33: https://github.com/divio/django-cms/archive/release/3.3.x.zip
+    django110: django-filer>=1.3
+    django111: Django>=1.11,<2.0
+    django111: django-mptt>=0.8
+    django111: django-taggit>=0.18
+    django111: django-polymorphic>=0.9
+    django111: django-filer>=1.3
     cms34: https://github.com/divio/django-cms/archive/release/3.4.x.zip
     -r{toxinidir}/requirements-test.txt
 
@@ -36,8 +39,8 @@ skip_install = true
 deps =
     sphinx
     sphinx-rtd-theme
-    Django<1.10
-    django-polymorphic<0.9
+    Django<2.0
+    django-polymorphic>=0.9
     -rrequirements-test.txt
 changedir=docs
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,isort,py{36,35,34,27}-django{110,111}-cms{34},py{35,34,27}-django{19}-cms{34},py{35,34,27}-django{18}-cms{34}
+envlist = docs,pep8,isort,py{36,35,34,27}-django{111,110,19,18}-cms{35,34}
 
 [testenv]
 commands = {env:COMMAND:python} setup.py test
@@ -23,6 +23,7 @@ deps =
     django111: django-polymorphic>=0.9
     django111: django-filer>=1.3
     cms34: https://github.com/divio/django-cms/archive/release/3.4.x.zip
+    cms35: https://github.com/divio/django-cms/archive/develop.zip
     -r{toxinidir}/requirements-test.txt
 
 [testenv:pep8]


### PR DESCRIPTION
* Add Django 1.11
* Add Python 3.6
* Drop django CMS 3.2, 3.3

Incorporate #74 for preview of django CMS 3.5
Fix #74 