### PR TITLE
Change method of patching PageAdmin

### DIFF
--- a/djangocms_page_meta/admin.py
+++ b/djangocms_page_meta/admin.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.admin.pageadmin import PageAdmin
 from cms.extensions import PageExtensionAdmin, TitleExtensionAdmin
-from cms.models import Page
 from cms.utils import get_language_from_request
 from django.conf import settings
 from django.contrib import admin
@@ -104,5 +103,3 @@ def get_form(self, request, obj=None, **kwargs):
     return form
 
 PageAdmin.get_form = get_form
-
-admin.site.unregister(Page)

--- a/djangocms_page_meta/admin.py
+++ b/djangocms_page_meta/admin.py
@@ -82,8 +82,8 @@ class TitleMetaAdmin(TitleExtensionAdmin):
 admin.site.register(TitleMeta, TitleMetaAdmin)
 
 
-# Monkey patch the PageAdmin
-_ORIGINAL_PAGEADMIN_GET_FORM = PageAdmin.get_form
+# Monkey patch the PageAdmin with a new get_form method
+_BASE_PAGEADMIN__GET_FORM = PageAdmin.get_form
 
 
 def get_form(self, request, obj=None, **kwargs):
@@ -94,7 +94,7 @@ def get_form(self, request, obj=None, **kwargs):
     overridden in djangocms-page-meta.
     """
     language = get_language_from_request(request, obj)
-    form = _ORIGINAL_PAGEADMIN_GET_FORM(self, request, obj, **kwargs)
+    form = _BASE_PAGEADMIN__GET_FORM(self, request, obj, **kwargs)
     if obj and not obj.get_meta_description(language=language):
         try:
             del form.base_fields['meta_description']

--- a/djangocms_page_meta/admin.py
+++ b/djangocms_page_meta/admin.py
@@ -87,11 +87,12 @@ _ORIGINAL_PAGEADMIN_GET_FORM = PageAdmin.get_form
 
 
 def get_form(self, request, obj=None, **kwargs):
-    '''
+    """
     Patched method for PageAdmin.get_form.
 
-    Returns a form without the base field 'meta_description'
-    '''
+    Returns a form without the base field 'meta_description', which is
+    overridden in djangocms-page-meta.
+    """
     language = get_language_from_request(request, obj)
     form = _ORIGINAL_PAGEADMIN_GET_FORM(self, request, obj, **kwargs)
     if obj and not obj.get_meta_description(language=language):

--- a/djangocms_page_meta/admin.py
+++ b/djangocms_page_meta/admin.py
@@ -96,10 +96,7 @@ def get_form(self, request, obj=None, **kwargs):
     language = get_language_from_request(request, obj)
     form = _BASE_PAGEADMIN__GET_FORM(self, request, obj, **kwargs)
     if obj and not obj.get_meta_description(language=language):
-        try:
-            del form.base_fields['meta_description']
-        except KeyError:
-            pass
+        form.base_fields.pop('meta_description', None)
 
     return form
 

--- a/tests/test_adminpage.py
+++ b/tests/test_adminpage.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+
+from django.contrib import admin
+from cms.models import Page
+from django.forms import fields
+
+from . import BaseTest
+
+PageAdmin = admin.site._registry[Page]
+
+
+class AdminPageTest(BaseTest):
+
+    def test_get_form_no_obj(self):
+        """
+        Test that the returned form has not been modified by the meta patch
+        when no page object is specified
+        """
+        request = self.get_page_request(None, self.user, '/', edit=True)
+        form = PageAdmin.get_form(request)
+        self.assertIsInstance(
+            form.base_fields.get('meta_description'),
+            fields.CharField
+        )
+
+    def test_get_form_with_obj(self):
+        """
+        Test that the returned form has been modified by the meta patch
+        """
+        page1, _page2 = self.get_pages()
+
+        request = self.get_page_request(page1, self.user, '/', edit=True)
+        form = PageAdmin.get_form(request, page1)
+        self.assertEqual(form.base_fields.get('meta_description'), None)

--- a/tests/test_adminpage.py
+++ b/tests/test_adminpage.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-from django.contrib import admin
 from cms.models import Page
+from django.contrib import admin
 from django.forms import fields
 
 from . import BaseTest
 
-PageAdmin = admin.site._registry[Page]
+page_admin = admin.site._registry[Page]
 
 
 class AdminPageTest(BaseTest):
@@ -18,7 +18,7 @@ class AdminPageTest(BaseTest):
         when no page object is specified
         """
         request = self.get_page_request(None, self.user, '/', edit=True)
-        form = PageAdmin.get_form(request)
+        form = page_admin.get_form(request)
         self.assertIsInstance(
             form.base_fields.get('meta_description'),
             fields.CharField
@@ -31,5 +31,5 @@ class AdminPageTest(BaseTest):
         page1, _page2 = self.get_pages()
 
         request = self.get_page_request(page1, self.user, '/', edit=True)
-        form = PageAdmin.get_form(request, page1)
+        form = page_admin.get_form(request, page1)
         self.assertEqual(form.base_fields.get('meta_description'), None)


### PR DESCRIPTION
This plugin is incompatible with one (or more) plugins provided by Divio due to the manner in which the PageAdmin is patched - the base class isn't read from the registry.  However, there is no good way to read that class from the registry without accessing private variables from within the CMS.

The method within this PR uses a monkey-patch style which is compatible with Divio's plugins, uses no private member access, should be OK with other changes to the base class, and should be easy to maintain going forward.