### PR TITLE
Read site_id from node if it's available

### DIFF
--- a/djangocms_page_meta/utils.py
+++ b/djangocms_page_meta/utils.py
@@ -12,7 +12,7 @@ def get_cache_key(page, language):
     Create the cache key for the current page and language
     """
     from cms.cache import _get_cache_key
-    site_id = page.site_id
+    site_id = page.node.site_id if hasattr(page, 'node') else page.site_id
     return _get_cache_key('page_meta', page, language, site_id)
 
 


### PR DESCRIPTION
Site id was moved from the page object to the node object, starting from 3.5 this now throws a warning. 
This change makes the package future proof for 3.6 while keeping the backward compatibility for 3.4 