### PR TITLE
Remove description when creating a CMS page

### DIFF
--- a/djangocms_page_meta/admin.py
+++ b/djangocms_page_meta/admin.py
@@ -90,12 +90,15 @@ def get_form(self, request, obj=None, **kwargs):
     """
     Patched method for PageAdmin.get_form.
 
-    Returns a form without the base field 'meta_description', which is
+    Returns a page form without the base field 'meta_description' which is
     overridden in djangocms-page-meta.
+
+    This is triggered in the page add view and in the change view if
+    the meta description of the page is empty.
     """
     language = get_language_from_request(request, obj)
     form = _BASE_PAGEADMIN__GET_FORM(self, request, obj, **kwargs)
-    if obj and not obj.get_meta_description(language=language):
+    if not obj or not obj.get_meta_description(language=language):
         form.base_fields.pop('meta_description', None)
 
     return form

--- a/tests/test_adminpage.py
+++ b/tests/test_adminpage.py
@@ -19,10 +19,7 @@ class AdminPageTest(BaseTest):
         """
         request = self.get_page_request(None, self.user, '/', edit=True)
         form = page_admin.get_form(request)
-        self.assertIsInstance(
-            form.base_fields.get('meta_description'),
-            fields.CharField
-        )
+        self.assertEqual(form.base_fields.get('meta_description'), None)
 
     def test_get_form_with_obj(self):
         """
@@ -33,3 +30,16 @@ class AdminPageTest(BaseTest):
         request = self.get_page_request(page1, self.user, '/', edit=True)
         form = page_admin.get_form(request, page1)
         self.assertEqual(form.base_fields.get('meta_description'), None)
+
+    def test_get_form_with_obj_description(self):
+        """
+        Test that the returned form has been modified by the meta patch
+        """
+        page1, _page2 = self.get_pages()
+        title = page1.get_title_obj('en')
+        title.meta_description = 'something'
+        title.save()
+
+        request = self.get_page_request(page1, self.user, '/', edit=True)
+        form = page_admin.get_form(request, page1)
+        self.assertNotEqual(form.base_fields.get('meta_description'), None)


### PR DESCRIPTION
I can't see any use case that needs the page description when creating a page
Addresses https://github.com/nephila/djangocms-page-meta/issues/60#issuecomment-376109024