### PR TITLE
Add documentation on hiding meta description field from the cms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,10 @@ Quickstart
 
 #. That's all!
 
+.. note:: Enabling this will **hide** django CMS own **Meta description** field to keep all the meta
+          information in the same part of the interface. If the django CMS field is set, it will still
+          be shown (and used by djangocms-page-meta).
+
 Dependencies
 ============
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -63,6 +63,9 @@ Generic HTML
 * keywords: HTML meta keywords
 
 
+.. note:: Enabling this will **hide** django CMS own **Meta description** field to keep all the meta
+          information in the same part of the interface. If the django CMS field is set, it will still
+          be shown (and used by djangocms-page-meta).
 
 
 OpenGraph


### PR DESCRIPTION
Given the number of requests received regarding this, we'd better document this behavior