### PR TITLE
Fix for CMS edit mode since 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea
 
 # Complexity
 output/*.html

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ nosetests.xml
 .project
 .pydevproject
 .idea
+.env
+.venv
+env
+venv
 
 # Complexity
 output/*.html

--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501
+exclude = migrations,.venv_*,docs

--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,0 @@
-[flake8]
-ignore = E501
-exclude = migrations,.venv_*,docs

--- a/djangocms_page_meta/cms_toolbars.py
+++ b/djangocms_page_meta/cms_toolbars.py
@@ -14,7 +14,7 @@ from .models import PageMeta, TitleMeta
 
 try:
     from django.core.urlresolvers import NoReverseMatch, reverse
-except ImportError:
+except ImportError:  # pragma: no cover
     from django.urls import NoReverseMatch, reverse
 
 try:

--- a/djangocms_page_meta/cms_toolbars.py
+++ b/djangocms_page_meta/cms_toolbars.py
@@ -13,9 +13,9 @@ from django.utils.translation import ugettext_lazy as _
 from .models import PageMeta, TitleMeta
 
 try:
-    from django.core.urlresolvers import NoReverseMatch, reverse
-except ImportError:  # pragma: no cover
     from django.urls import NoReverseMatch, reverse
+except ImportError:  # pragma: no cover
+    from django.core.urlresolvers import NoReverseMatch, reverse
 
 try:
     from cms.utils import get_cms_setting
@@ -49,9 +49,9 @@ class PageToolbarMeta(CMSToolbar):
         can_change = self.request.current_page and permission
         if has_global_current_page_change_permission or can_change:
             try:
-                not_edit_mode = not self.toolbar.edit_mode
-            except AttributeError:
                 not_edit_mode = not self.toolbar.edit_mode_active
+            except AttributeError:
+                not_edit_mode = not self.toolbar.edit_mode
 
             current_page_menu = self.toolbar.get_or_create_menu('page')
             super_item = current_page_menu.find_first(

--- a/tests/test_adminpage.py
+++ b/tests/test_adminpage.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from cms.models import Page
 from django.contrib import admin
-from django.forms import fields
 
 from . import BaseTest
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,isort,py{36,35,34,27}-django{111,110,19,18}-cms{35,34}
+envlist = docs,pep8,isort,py{36,35,34,27}-django{111,110,19,18}-cms{36,35,34}
 
 [testenv]
 commands = {env:COMMAND:python} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
 
 [testenv:pep8]
 deps = flake8
-commands = flake8 {toxinidir}/djangocms_page_meta
+commands = flake8
 skip_install = true
 
 [testenv:isort]

--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,12 @@ deps =
     django111: django-filer>=1.3
     cms34: https://github.com/divio/django-cms/archive/release/3.4.x.zip
     cms35: https://github.com/divio/django-cms/archive/release/3.5.x.zip
+    cms36: https://github.com/divio/django-cms/archive/release/3.6.x.zip
     -r{toxinidir}/requirements-test.txt
 
 [testenv:pep8]
 deps = flake8
-commands = flake8
+commands = flake8 {toxinidir}/djangocms_page_meta
 skip_install = true
 
 [testenv:isort]


### PR DESCRIPTION
Added `try/except` block for the old `edit_mode` attribute vs the new `edit_mode_active` property.

Also added `try/except` on django urls for support going forward.