### PR TITLE
Adding on_delete to a field in the initial migration.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,9 @@ Meta tag information for django CMS 3 pages
 
 Python: 2.7, 3.4, 3.5. 3.6
 
-Django: 1.8 to 1.11
+Django: 1.8 to 2.1
 
-django CMS: 3.4 (and develop/3.5)
+django CMS: 3.4, 3.5, 3.6
 
 .. warning:: Since version 0.7, the support for Python 2.6, Python 3.3, Django<1.8 and django CMS<3.2
              has been dropped

--- a/djangocms_page_meta/migrations/0001_initial.py
+++ b/djangocms_page_meta/migrations/0001_initial.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
                 ('gplus_description', models.CharField(default=b'', max_length=400, verbose_name='Google+ Description', blank=True)),
                 ('extended_object', models.OneToOneField(editable=False, to='cms.Title', on_delete=models.CASCADE)),
                 ('image', filer.fields.file.FilerFileField(related_name='djangocms_page_meta_title', blank=True, to='filer.File', help_text='If empty, page image will be used for all languages.', null=True, on_delete=models.CASCADE)),
-                ('public_extension', models.OneToOneField(related_name='draft_extension', null=True, editable=False, to='djangocms_page_meta.TitleMeta')),
+                ('public_extension', models.OneToOneField(related_name='draft_extension', null=True, editable=False, to='djangocms_page_meta.TitleMeta', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'Page meta info (language-dependent)',


### PR DESCRIPTION
- A field was missed in the initial migration in the previous Django 2.x PR
- Django 2.1 and Django CMS 3.6 compatibility added to README.rst