### PR TITLE
Fixed n+1 select problem

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 ===================
 
 * Move from djangocms-helper to django-app-helper
+* Improve toolbar performance
 
 0.9.0 (2019-08-22)
 ==================

--- a/djangocms_page_meta/cms_toolbars.py
+++ b/djangocms_page_meta/cms_toolbars.py
@@ -91,20 +91,20 @@ class PageToolbarMeta(CMSToolbar):
                 site_id = self.page.node.site_id
             except AttributeError:  # CMS_3_4
                 site_id = self.page.site_id
-            for title in self.page.title_set.filter(
+            titles = self.page.title_set.filter(
                 language__in=get_language_list(site_id)
-            ):
+            )
+
+            title_extensions = {t.id: t for t in TitleMeta.objects.filter(
+                extended_object_id__in=[title.id for title in titles]
+            )}
+
+            for title in titles:
                 try:
-                    title_extension = TitleMeta.objects.get(
-                        extended_object_id=title.pk
-                    )
-                except TitleMeta.DoesNotExist:
-                    title_extension = None
-                try:
-                    if title_extension:
+                    if title.pk in title_extensions:
                         url = reverse(
                             'admin:djangocms_page_meta_titlemeta_change',
-                            args=(title_extension.pk,)
+                            args=(title_extensions[title.pk].pk,)
                         )
                     else:
                         url = '%s?extended_object=%s' % (

--- a/djangocms_page_meta/cms_toolbars.py
+++ b/djangocms_page_meta/cms_toolbars.py
@@ -95,7 +95,7 @@ class PageToolbarMeta(CMSToolbar):
                 language__in=get_language_list(site_id)
             )
 
-            title_extensions = {t.id: t for t in TitleMeta.objects.filter(
+            title_extensions = {t.extended_object_id: t for t in TitleMeta.objects.filter(
                 extended_object_id__in=[title.id for title in titles]
             )}
 


### PR DESCRIPTION
The original code called a get() in a loop which causes an n+1 select problem which is equal to the number of languages for the page. Fixed by reducing it to a single query.