### PR TITLE
Fix setup.cfg and pyproject.toml package name

### DIFF
--- a/changes/138.bugfix
+++ b/changes/138.bugfix
@@ -1,0 +1,1 @@
+Fix setup.cfg and pyproject.toml package name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 119
 target-version = ["py36"]
-include = 'meta/*py'
+include = 'djangocms_page_meta/*py'
 
 [tool.towncrier]
 package = "djangocms-page-meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ values =
     rc
     gamma
 
-[bumpversion:file:meta/__init__.py]
+[bumpversion:file:djangocms_page_meta/__init__.py]
 
 [metadata]
 name = djangocms-page-meta
@@ -64,7 +64,7 @@ zip_safe = False
 
 [options.package_data]
 * = *.txt, *.rst
-meta = *.html *.png *.gif *js *jpg *jpeg *svg *py *mo *po
+djangocms_page_meta = *.html *.png *.gif *js *jpg *jpeg *svg *py *mo *po
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
# Description

Fix `setup.cfg` and `pyproject.toml` package name

## References

Fix #138 