### PR TITLE
Add support for Django 3.2 / django CMS 3.10

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,26 +8,26 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10.x]
         toxenv: [pep8, isort, black, pypi-description, docs, towncrier]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.toxenv }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.toxenv }}
     - name: Cache tox
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: .tox
         key: ${{ runner.os }}-lint-${{ matrix.toxenv }}-${{ hashFiles('setup.cfg') }}
@@ -35,7 +35,7 @@ jobs:
           ${{ runner.os }}-lint-${{ matrix.toxenv }}-
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools tox>=1.8
+        python -m pip install --upgrade pip setuptools tox>3.23
     - name: Test with tox
       run: |
         tox -e${{ matrix.toxenv }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,20 +8,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.toxenv }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.toxenv }}
     - name: Cache tox
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: .tox
         key: ${{ runner.os }}-tox-release-${{ hashFiles('setup.cfg') }}
@@ -29,7 +29,7 @@ jobs:
           ${{ runner.os }}-tox-release-
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools tox>=1.8
+        python -m pip install --upgrade pip setuptools tox>3.23
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,27 +8,29 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.7, 3.6]
-        django: [31, 30, 22]
-        cms: [38, 37]
+        python-version: [3.10.x, 3.9, 3.8, 3.7]
+        django: [32,22]
+        cms: [39,38,37]
         exclude:
-          - django: 31
+          - django: 32
             cms: 37
+          - django: 32
+            cms: 38
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.toxenv }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.toxenv }}
     - name: Cache tox
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: .tox
         key: ${{ runner.os }}-tox-${{ format('{{py{0}-django{1}-cms{2}}}', matrix.python-version, matrix.django, matrix.cms) }}-${{ hashFiles('setup.cfg') }}
@@ -37,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install gettext
-        python -m pip install --upgrade pip tox>=3.5
+        python -m pip install --upgrade pip tox>3.23
     - name: Test with tox
       env:
         TOX_ENV: ${{ format('py-django{1}-cms{2}', matrix.python-version, matrix.django, matrix.cms) }}
@@ -48,11 +50,11 @@ jobs:
         tox -e$TOX_ENV
         .tox/$TOX_ENV/bin/coverage xml
         .tox/$TOX_ENV/bin/coveralls
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false
     services:
       redis:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     rev: v4.3.0
     hooks:
       - id: trailing-whitespace
+        exclude: "setup.cfg"
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
@@ -60,3 +61,6 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+ci:
+  skip:
+    - towncrier

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,7 +1,0 @@
-update: all
-pin: False
-branch:
-schedule: "every day"
-search: True
-branch_prefix: pyup/
-close_prs: True

--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,11 @@ djangocms-page-meta
 
 Meta tag information for django CMS 3 pages
 
-Python: 3.6, 3.7, 3.8
+Python: 3.7, 3.8, 3.9, 3.10
 
-Django: 2.2, 3.0, 3.1
+Django: 2.2, 3.2
 
-django CMS: 3.7, 3.8
+django CMS: 3.7 - 3.10
 
 
 **********
@@ -29,16 +29,12 @@ Quickstart
 
 #. Then add it to INSTALLED_APPS along with its dependencies::
 
-        'filer',
-        'meta',
-        'easy_thumbnails',
-        'djangocms_page_meta',
+        "filer",
+        "meta",
+        "easy_thumbnails",
+        "djangocms_page_meta",
 
-#. Synchronize the database::
-
-        $ python manage.py syncdb
-
-   or migrate::
+#. Migrate the database::
 
         $ python manage.py migrate
 

--- a/changes/151.bugfix
+++ b/changes/151.bugfix
@@ -1,0 +1,1 @@
+Add support for Django 3.2 / django CMS 3.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,12 +43,12 @@ classifiers =
 	Natural Language :: English
 	Framework :: Django
 	Framework :: Django :: 2.2
-	Framework :: Django :: 3.0
-	Framework :: Django :: 3.1
+	Framework :: Django :: 3.2
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 
 [options]
 include_package_data = True
@@ -59,7 +59,7 @@ install_requires =
 setup_requires =
 	setuptools
 packages = djangocms_page_meta
-python_requires = >=3.6
+python_requires = >=3.7
 test_suite = cms_helper.run
 zip_safe = False
 
@@ -69,7 +69,7 @@ djangocms_page_meta = *.html *.png *.gif *js *jpg *jpeg *svg *py *mo *po
 
 [options.extras_require]
 docs =
-	django<3.1
+	django<4.0
 	djangocms-page-tags
 
 [upload]

--- a/tasks.py
+++ b/tasks.py
@@ -8,7 +8,7 @@ from invoke import task
 
 DOCS_PORT = os.environ.get("DOCS_PORT", 8000)
 #: branch prefixes for which some checks are skipped
-SPECIAL_BRANCHES = ("master", "develop", "release")
+SPECIAL_BRANCHES = ("master", "develop", "release", "support/4.0.x")
 
 
 @task
@@ -109,15 +109,19 @@ def coverage(c):
 
 
 @task
-def tag_release(c, level):
+def tag_release(c, level, new_version=""):
     """Tag release version."""
-    c.run("bumpversion --list %s --no-tag" % level)
+    if new_version:
+        new_version = f" --new-version {new_version}"
+    c.run(f"bumpversion --list {level} --no-tag{new_version}")
 
 
 @task
-def tag_dev(c, level="patch"):
+def tag_dev(c, level="patch", new_version=""):
     """Tag development version."""
-    c.run("bumpversion --list %s --message='Bump develop version [ci skip]' --no-tag" % level)
+    if new_version:
+        new_version = f" --new-version {new_version}"
+    c.run(f"bumpversion --list {level} --message='Bump develop version [ci skip]' --no-tag{new_version}")
 
 
 @task(pre=[clean])

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -3,7 +3,7 @@ from cms.utils.i18n import get_language_object
 from django.contrib.auth.models import Permission, User
 from django.test.utils import override_settings
 from django.urls import reverse
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from djangocms_page_meta.cms_toolbars import PAGE_META_ITEM_TITLE, PAGE_META_MENU_TITLE
 from djangocms_page_meta.models import PageMeta, TitleMeta
@@ -38,7 +38,7 @@ class ToolbarTest(BaseTest):
         try:
             self.assertEqual(page_menu, [])
         except AssertionError:
-            meta_menu = page_menu[0].item.find_items(SubMenu, name=force_text(PAGE_META_MENU_TITLE))
+            meta_menu = page_menu[0].item.find_items(SubMenu, name=force_str(PAGE_META_MENU_TITLE))
             self.assertEqual(meta_menu, [])
 
     def test_perm(self):
@@ -54,10 +54,8 @@ class ToolbarTest(BaseTest):
         toolbar = CMSToolbar(request)
         toolbar.get_left_items()
         page_menu = toolbar.menus["page"]
-        meta_menu = page_menu.find_items(SubMenu, name=force_text(PAGE_META_MENU_TITLE))[0].item
-        self.assertEqual(
-            len(meta_menu.find_items(ModalItem, name="{}...".format(force_text(PAGE_META_ITEM_TITLE)))), 1
-        )
+        meta_menu = page_menu.find_items(SubMenu, name=force_str(PAGE_META_MENU_TITLE))[0].item
+        self.assertEqual(len(meta_menu.find_items(ModalItem, name="{}...".format(force_str(PAGE_META_ITEM_TITLE)))), 1)
 
     @override_settings(CMS_PERMISSION=True)
     def test_perm_permissions(self):
@@ -76,7 +74,7 @@ class ToolbarTest(BaseTest):
         try:
             self.assertEqual(page_menu, [])
         except AssertionError:
-            meta_menu = page_menu[0].item.find_items(SubMenu, name=force_text(PAGE_META_MENU_TITLE))
+            meta_menu = page_menu[0].item.find_items(SubMenu, name=force_str(PAGE_META_MENU_TITLE))
             self.assertEqual(meta_menu, [])
 
     def test_toolbar(self):
@@ -109,9 +107,9 @@ class ToolbarTest(BaseTest):
             toolbar = CMSToolbar(request)
             toolbar.get_left_items()
             page_menu = toolbar.menus["page"]
-            meta_menu = page_menu.find_items(SubMenu, name=force_text(PAGE_META_MENU_TITLE))[0].item
+            meta_menu = page_menu.find_items(SubMenu, name=force_str(PAGE_META_MENU_TITLE))[0].item
             self.assertEqual(
-                len(meta_menu.find_items(ModalItem, name="{}...".format(force_text(PAGE_META_ITEM_TITLE)))), 1
+                len(meta_menu.find_items(ModalItem, name="{}...".format(force_str(PAGE_META_ITEM_TITLE)))), 1
             )
             self.assertEqual(len(meta_menu.find_items(ModalItem)), len(NEW_CMS_LANGS[1]) + 1)
 
@@ -128,8 +126,8 @@ class ToolbarTest(BaseTest):
         toolbar = CMSToolbar(request)
         toolbar.get_left_items()
         page_menu = toolbar.menus["page"]
-        meta_menu = page_menu.find_items(SubMenu, name=force_text(PAGE_META_MENU_TITLE))[0].item
-        pagemeta_menu = meta_menu.find_items(ModalItem, name="{}...".format(force_text(PAGE_META_ITEM_TITLE)))
+        meta_menu = page_menu.find_items(SubMenu, name=force_str(PAGE_META_MENU_TITLE))[0].item
+        pagemeta_menu = meta_menu.find_items(ModalItem, name="{}...".format(force_str(PAGE_META_ITEM_TITLE)))
         self.assertEqual(len(pagemeta_menu), 1)
         self.assertTrue(
             pagemeta_menu[0].item.url.startswith(

--- a/tox.ini
+++ b/tox.ini
@@ -8,19 +8,22 @@ envlist =
     pep8
     pypi-description
     towncrier
-    py{38,37,36}-django{31}-cms{38}
-    py{38,37,36}-django{30}-cms{38,37}
-    py{38,37,36}-django{22}-cms{38,37}
+    py{310}-django{32}-cms{311,310}
+    py{39,38,37}-django{32}-cms{311,310,39}
+    py{39,38,37}-django{22}-cms{311,310,39,38,37}
+minversion = 3.22
 
 [testenv]
 commands = {env:COMMAND:python} cms_helper.py djangocms_page_meta test {posargs}
 deps =
     django22: Django>=2.2,<3.0
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
+    django32: Django>=3.1,<3.2
     cms37: https://github.com/divio/django-cms/archive/release/3.7.x.zip
     cms38: https://github.com/divio/django-cms/archive/release/3.8.x.zip
-    djangocms-page-tags
+    cms39: https://github.com/divio/django-cms/archive/release/3.9.x.zip
+    cms310: https://github.com/divio/django-cms/archive/release/3.10.x.zip
+    cms311: https://github.com/divio/django-cms/archive/release/3.11.x.zip
+    djangocms-page-tags>=1.0.0
     -r{toxinidir}/requirements-test.txt
 passenv =
     COMMAND
@@ -48,7 +51,7 @@ skip_install = true
 [testenv:isort]
 commands =
     {envpython} -m isort -c --df djangocms_page_meta tests
-deps = isort>5,<5.1
+deps = isort>5.10,<5.11
 skip_install = true
 
 [testenv:isort_format]


### PR DESCRIPTION
Co-authored-by: Viliam Mihálik <viliam.mihalik@smartbase.sk>

Update tools to support Django 3.2 / django CMS 3.10

Remove incompatibilities with django 4.0 even if we cannot support it officially because we need further testing

## References

Fix #149

Fix #151 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-page-meta.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-page-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
