### PR TITLE
fix: update version of dep. "filer" 1.2 → 3.0

### DIFF
--- a/changes/173.bugfix
+++ b/changes/173.bugfix
@@ -1,0 +1,1 @@
+Update filer dependency to avoid migration error from 155.feature

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ include_package_data = True
 install_requires =
 	django-cms>=3.7
 	django-meta>=2.0.0
-	django-filer>=1.2
+	django-filer>=3.0
 setup_requires =
 	setuptools
 packages = djangocms_page_meta


### PR DESCRIPTION
# Description

* Update dependency Filer from v1.2+ to v3.0+
* Prevents error from DjangoCMS Page Meta migration using unavailable Filer migration

## References

Fix #173

# Checklist

* [x] I have read the [contribution guide](https://djangocms-page-meta.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`[^1]
* [x] ``changes`` file included (see [docs](https://djangocms-page-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* ~~Usage documentation added in case of new features~~[^2]
* ~~Tests added~~[^2]

<details><summary><code>tox</code> output summary</summary>

```
  black: OK (0.42=setup[0.02]+cmd[0.39] seconds)
  blacken: OK (0.13=setup[0.00]+cmd[0.12] seconds)
  docs: OK (1.21=setup[0.01]+cmd[1.20] seconds)
  isort: OK (0.12=setup[0.00]+cmd[0.12] seconds)
  isort_format: OK (0.13=setup[0.00]+cmd[0.12] seconds)
  ruff: OK (0.14=setup[0.00]+cmd[0.04,0.10] seconds)
  pypi-description: OK (21.03=setup[0.01]+cmd[0.28,13.29,7.26,0.20] seconds)
  towncrier: OK (0.11=setup[0.00]+cmd[0.11] seconds)
  py311-django42-cms311: OK (5.35=setup[1.85]+cmd[3.50] seconds)
  py311-django41-cms311: OK (5.21=setup[1.71]+cmd[3.50] seconds)
  py310-django42-cms311: SKIP (0.25 seconds)
  py310-django41-cms311: SKIP (0.00 seconds)
  py39-django42-cms311: OK (8.43=setup[2.46]+cmd[5.97] seconds)
  py39-django41-cms311: OK (27.03=setup[21.14]+cmd[5.90] seconds)
  py311-django32-cms311: OK (19.84=setup[15.53]+cmd[4.32] seconds)
  py311-django32-cms39: OK (19.93=setup[15.46]+cmd[4.48] seconds)
  py310-django32-cms311: SKIP (0.00 seconds)
  py310-django32-cms39: SKIP (0.00 seconds)
  py39-django32-cms311: OK (25.12=setup[18.82]+cmd[6.30] seconds)
  py39-django32-cms39: OK (25.23=setup[17.32]+cmd[7.91] seconds)
  congratulations :) (159.73 seconds)
```

</details>


[^1]: I did `pip install -r requirements-test.txt` and `pip install -e .`, but when I ran `inv lint`, the output was `zsh: command not found: inv`. Consider expanding on this instruction… for noobs like me.
[^2]: Seemed irrelevant to the change.