### PR TITLE
Set default_auto_field in AppConfig

### DIFF
--- a/changes/181.bugfix
+++ b/changes/181.bugfix
@@ -1,0 +1,1 @@
+Set default_auto_field in AppConfig to avoid migrations problem if DEFAULT_AUTO_FIELD is different

--- a/djangocms_page_meta/apps.py
+++ b/djangocms_page_meta/apps.py
@@ -5,3 +5,4 @@ from django.utils.translation import gettext_lazy as _
 class PageMetaConfig(AppConfig):
     name = "djangocms_page_meta"
     verbose_name = _("django CMS Page Meta")
+    default_auto_field = "django.db.models.BigAutoField"


### PR DESCRIPTION
# Description

Set default_auto_field in AppConfig to avoid migrations problem if DEFAULT_AUTO_FIELD is different

## References

Fix #181 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-page-meta.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-page-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
