### PR TITLE
Bug/#214-Fix misnamed 'change_page' permission

### DIFF
--- a/changes/214.bugfix
+++ b/changes/214.bugfix
@@ -1,0 +1,1 @@
+Fix misnamed 'change_page' permission when checking if user has change permission on current page.

--- a/djangocms_page_meta/cms_toolbars.py
+++ b/djangocms_page_meta/cms_toolbars.py
@@ -36,7 +36,7 @@ class PageToolbarMeta(CMSToolbar):
         # check global permissions if CMS_PERMISSIONS is active
         if get_cms_setting("PERMISSION"):
             has_global_current_page_change_permission = has_page_permission(
-                self.request.user, self.request.current_page, "change"
+                self.request.user, self.request.current_page, "change_page"
             )
         else:
             has_global_current_page_change_permission = False


### PR DESCRIPTION
# Description

Fixes the KeyError that occurs in Django CMS 3.11.8 or later.

PageToolbarMeta.populate tests for a permission named `change` but the proper permission name is `change_page`, causing a `KeyError` to be raised with Django CMS 3.11.8 or later. "change_page" has been used since at least Django CMS 3.4.0, but a refactoring of Django CMS' `cms.utils.has_page_permission` function in 3.11.8 now results in a `KeyError` being raised.

## References

Fix #214 

# Checklist

* [X] I have read the [contribution guide](https://djangocms-page-meta.readthedocs.io/en/latest/contributing.html)
* [X] Code lint checked via `inv lint`
* [X] ``changes`` file included (see [docs](https://djangocms-page-meta.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))